### PR TITLE
remove second odh instance

### DIFF
--- a/values-factory.yaml
+++ b/values-factory.yaml
@@ -13,11 +13,6 @@ site:
   operatorgroupExcludes:
   - manuela-factory-ml-workspace
 
-  subscriptions:
-  - name: opendatahub-operator
-    source: community-operators
-    csv: opendatahub-operator.v1.1.0
-
   - name: seldon-operator
     namespace: manuela-stormshift-messaging
     source: community-operators


### PR DESCRIPTION
Remove the duplicate install of ODH to resolve warning in Argo.

Partially resolves #6 