### PR TITLE
Revert "temp change channel for 4.7"

### DIFF
--- a/values-datacenter.yaml
+++ b/values-datacenter.yaml
@@ -21,7 +21,7 @@ site:
   subscriptions:
   - name: ocs-operator
     namespace: openshift-storage
-    channel: stable-4.7
+    channel: stable-4.8
   
   - name: advanced-cluster-management
     namespace: open-cluster-management


### PR DESCRIPTION
This reverts commit 5071899c1e0a9b039bbd875bd39ae1cf051c1063.
Working again on OCP 4.8 instead of OCP 4.7.